### PR TITLE
Rewrite Notification Service

### DIFF
--- a/bot/core.py
+++ b/bot/core.py
@@ -2,7 +2,6 @@ import datetime
 import sqlite3
 from typing import Any
 
-import string
 import discord
 from discord import app_commands
 from discord.ext import tasks
@@ -10,9 +9,7 @@ from utils.factory import PREFIX, get_app
 from funcs import (
     cancel_cfd,
     create_cfd,
-    get_alliance_tag_from_id,
     get_channel_from_id,
-    get_connection_path,
     insert_defense_thread,
 )
 from services.analytics_service import AnalyticsService

--- a/bot/core.py
+++ b/bot/core.py
@@ -217,12 +217,17 @@ class Core(discord.Client):
         query = "select * from v_player_change where alliance_changed=1"
         rows = conn.execute(query)
         for row in rows:
+            timestamp = datetime.datetime.strptime(row[11], "%Y-%m-%d")
+            if timestamp < datetime.datetime.utcnow() - datetime.timedelta(days=1):
+                logger.info("Skipping all alerts because the data is too old.")
+                return  # all data will be too old in this case
+
             # If a channel exists in the guild that matches the player_name in the result, send an alert
             channel_name = row[1].replace(" ", "-").lower()
             channel_name = channel_name.translate(
                 str.maketrans("", "", string.punctuation)
             )
-            logger.info(f"Checking for channel {channel_name}")
+            logger.debug(f"Checking for channel {channel_name}")
             channel = discord.utils.get(guild.text_channels, name=channel_name)
             if channel is not None:
                 logger.info(f"Found channel {channel}")

--- a/bot/funcs.py
+++ b/bot/funcs.py
@@ -8,7 +8,7 @@ from utils.constants import (
     ConfigKeys,
 )
 from utils.logger import logger
-from utils.config_manager import read_config_str, update_config
+from services.config_service import read_config_str, update_config
 
 
 def init(message):

--- a/bot/handlers/base_app.py
+++ b/bot/handlers/base_app.py
@@ -2,7 +2,7 @@ from typing import List
 import discord
 
 from utils.constants import BOT_SERVERS_DB_PATH, ConfigKeys
-from utils.config_manager import read_config_str
+from services.config_service import read_config_str
 
 
 class BaseApp:

--- a/bot/handlers/boink_app.py
+++ b/bot/handlers/boink_app.py
@@ -136,6 +136,7 @@ class BoinkApp(BaseApp):
         game_server = read_config_str(self.guild_id, ConfigKeys.GAME_SERVER, "")
 
         if game_server == "":
+            logger.error(f"No game_server set for {self.guild_id}")
             embed = discord.Embed(color=Colors.ERROR)
             embed.add_field(name="Error", value="No game_server set.")
             await message.channel.send(embed=embed)
@@ -202,6 +203,7 @@ class BoinkApp(BaseApp):
 
                 await message.channel.send(embed=embed)
             else:
+                logger.error(f"No results found for {ign} in the map")
                 raise Exception("No results found")
         except Exception as e:
             logger.warn(

--- a/bot/handlers/boink_app.py
+++ b/bot/handlers/boink_app.py
@@ -21,7 +21,7 @@ from utils.decorators import (
 from utils.errors import incorrect_roles_error, invalid_input_error, no_db_error
 from utils.logger import logger
 from utils.printers import rows_to_piped_strings
-from services.config_service import read_config_str, update_config
+from services.config_service import dump_config, read_config_str, update_config
 from utils.constants import ConfigKeys
 from .base_app import BaseApp
 
@@ -134,6 +134,8 @@ class BoinkApp(BaseApp):
     @is_dev_or_user_or_admin_privs
     async def search(self, params, message):
         game_server = read_config_str(self.guild_id, ConfigKeys.GAME_SERVER, "")
+
+        logger.debug(f"Config Dump: {dump_config()}")
 
         if game_server == "":
             logger.error(f"No game_server set for {self.guild_id}")

--- a/bot/handlers/boink_app.py
+++ b/bot/handlers/boink_app.py
@@ -1,6 +1,6 @@
 import sqlite3
 import traceback
-from utils.analytics_manager import AnalyticsManager
+from services.analytics_service import AnalyticsService
 import discord
 import pandas as pd
 from funcs import (
@@ -21,7 +21,7 @@ from utils.decorators import (
 from utils.errors import incorrect_roles_error, invalid_input_error, no_db_error
 from utils.logger import logger
 from utils.printers import rows_to_piped_strings
-from utils.config_manager import read_config_str, update_config
+from services.config_service import read_config_str, update_config
 from utils.constants import ConfigKeys
 from .base_app import BaseApp
 
@@ -230,6 +230,6 @@ class BoinkApp(BaseApp):
         # Stats command is for testing only
         raise Exception("Stats command disabled")
 
-        analytics = AnalyticsManager()
+        analytics = AnalyticsService()
         stats = analytics.get_command_stats()
         await message.channel.send(content=str(stats))

--- a/bot/handlers/def_app.py
+++ b/bot/handlers/def_app.py
@@ -6,7 +6,7 @@ from utils.decorators import *
 from utils.printers import *
 from utils.logger import logger
 from funcs import *
-from utils.config_manager import read_config_str
+from services.config_service import read_config_str
 from utils.constants import ConfigKeys
 
 

--- a/bot/services/analytics_service.py
+++ b/bot/services/analytics_service.py
@@ -4,12 +4,12 @@ from utils.logger import logger
 from utils.constants import ANALYTICS_DB_PATH
 
 
-class AnalyticsManager:
+class AnalyticsService:
     """Class to manage analytics data across all Discord servers"""
 
     def __init__(self):
         self.db_path = ANALYTICS_DB_PATH
-        logger.info("Analytics Manager initialized")
+        logger.info("Analytics Service initialized")
 
     def record_command(
         self,

--- a/bot/services/config_service.py
+++ b/bot/services/config_service.py
@@ -60,6 +60,15 @@ class ConfigService:
         """Get the raw ConfigParser object"""
         return self._config
 
+    def dump_config(self) -> dict:
+        """Return a dictionary of all configuration values"""
+        config_dict = {}
+        for section in self._config.sections():
+            config_dict[section] = {}
+            for key, value in self._config.items(section):
+                config_dict[section][key] = value
+        return config_dict
+
 
 config_service = ConfigService.get_instance()
 
@@ -74,3 +83,7 @@ def read_config_bool(section: str, key: str, default: bool = False) -> bool:
 
 def update_config(section: str, key: str, value: str) -> bool:
     return config_service.update_config(section, key, value)
+
+
+def dump_config() -> dict:
+    return config_service.dump_config()

--- a/bot/services/config_service.py
+++ b/bot/services/config_service.py
@@ -3,24 +3,24 @@ from typing import Optional
 from utils.logger import logger
 
 
-class ConfigManager:
-    _instance: Optional["ConfigManager"] = None
+class ConfigService:
+    _instance: Optional["ConfigService"] = None
     _config: Optional[configparser.ConfigParser] = None
 
     def __init__(self):
-        if ConfigManager._instance is not None:
+        if ConfigService._instance is not None:
             raise Exception(
-                "ConfigManager is a singleton class. Use ConfigManager.get_instance()"
+                "ConfigService is a singleton class. Use ConfigService.get_instance()"
             )
 
-        ConfigManager._instance = self
+        ConfigService._instance = self
         self._config = configparser.ConfigParser()
         self._reload_config()
 
-    def get_instance() -> "ConfigManager":
-        if ConfigManager._instance is None:
-            ConfigManager()
-        return ConfigManager._instance
+    def get_instance() -> "ConfigService":
+        if ConfigService._instance is None:
+            ConfigService()
+        return ConfigService._instance
 
     def _reload_config(self) -> None:
         """Reload the config from disk"""
@@ -61,16 +61,16 @@ class ConfigManager:
         return self._config
 
 
-config_manager = ConfigManager.get_instance()
+config_service = ConfigService.get_instance()
 
 
 def read_config_str(section: str, key: str, default: str = "") -> str:
-    return config_manager.read_config_str(section, key, default)
+    return config_service.read_config_str(section, key, default)
 
 
 def read_config_bool(section: str, key: str, default: bool = False) -> bool:
-    return config_manager.read_config_bool(section, key, default)
+    return config_service.read_config_bool(section, key, default)
 
 
 def update_config(section: str, key: str, value: str) -> bool:
-    return config_manager.update_config(section, key, value)
+    return config_service.update_config(section, key, value)

--- a/bot/services/notification_service.py
+++ b/bot/services/notification_service.py
@@ -1,0 +1,103 @@
+import datetime
+import sqlite3
+import string
+import discord
+from utils.constants import ConfigKeys
+from utils.logger import logger
+from services.config_service import read_config_str
+from funcs import get_alliance_tag_from_id, get_connection_path
+
+
+class NotificationService:
+    """Service to manage notifications and alerts across Discord servers"""
+
+    def __init__(self):
+        logger.info("Notification Service initialized")
+
+    async def send_alerts_for_guild(self, guild: discord.Guild) -> None:
+        """Send alliance change alerts for a specific guild"""
+        logger.info(f"Sending alerts for {str(guild.id)}")
+
+        # Get game server config and connect to DB
+        game_server = read_config_str(guild.id, ConfigKeys.GAME_SERVER, "")
+        conn = sqlite3.connect(get_connection_path(game_server))
+
+        await self._send_player_deleted_alert(conn, guild)
+
+        try:
+            # Get all players that changed alliances
+            query = "select * from v_player_change where alliance_changed=1 and current_population>0"
+            rows = conn.execute(query)
+
+            for row in rows:
+                # Check if data is too old
+                timestamp = datetime.datetime.strptime(row[11], "%Y-%m-%d")
+                if timestamp < datetime.datetime.utcnow() - datetime.timedelta(days=1):
+                    logger.info("Skipping all alerts because the data is too old.")
+                    return
+
+                # Format channel name from player name
+                channel_name = row[1].replace(" ", "-").lower()
+                channel_name = channel_name.translate(
+                    str.maketrans("", "", string.punctuation)
+                )
+                logger.info(f"Checking for channel {channel_name}")
+
+                # Find matching channel
+                channel = discord.utils.get(guild.text_channels, name=channel_name)
+                if channel is not None:
+                    logger.info(f"Found channel {channel}")
+                    await self._send_player_alert(conn, channel, row)
+
+        except Exception as e:
+            logger.error(f"Error sending alerts for guild {guild.id}: {e}")
+        finally:
+            conn.close()
+
+    async def _send_player_alert(
+        self, conn: sqlite3.Connection, channel: discord.TextChannel, player_data: tuple
+    ) -> None:
+        """Send an alert about player changes to the specified channel"""
+        try:
+            # Player changed alliances
+            old_alliance = get_alliance_tag_from_id(conn, player_data[3])
+            new_alliance = get_alliance_tag_from_id(conn, player_data[2])
+
+            await channel.send(
+                f"Player {player_data[1]} has changed alliances from "
+                f"**{old_alliance}** to **{new_alliance}**"
+            )
+        except Exception as e:
+            logger.error(f"Error sending player alert: {e}")
+
+    async def _send_player_deleted_alert(
+        self, conn: sqlite3.Connection, guild: discord.Guild
+    ) -> None:
+        """Send an alert about player deletion to the specified channel"""
+        try:
+            # Get all players that changed alliances
+            query = "select * from v_player_change where current_population=0"
+            rows = conn.execute(query)
+
+            for row in rows:
+                # Check if data is too old
+                timestamp = datetime.datetime.strptime(row[11], "%Y-%m-%d")
+                if timestamp < datetime.datetime.now() - datetime.timedelta(days=1):
+                    logger.info("Skipping all alerts because the data is too old.")
+                    return
+
+                # Format channel name from player name
+                channel_name = row[1].replace(" ", "-").lower()
+                channel_name = channel_name.translate(
+                    str.maketrans("", "", string.punctuation)
+                )
+                logger.debug(f"Checking for channel {channel_name}")
+
+                # Find matching channel
+                channel = discord.utils.get(guild.text_channels, name=channel_name)
+                if channel is not None:
+                    logger.info(f"Found channel {channel}")
+                    await channel.send(f"Player {row[1]} has deleted their account.")
+
+        except Exception as e:
+            logger.error(f"Error sending alerts for guild {guild.id}: {e}")

--- a/bot/services/notification_service.py
+++ b/bot/services/notification_service.py
@@ -81,13 +81,20 @@ class NotificationService:
         """Send an alert about player changes to the specified channel"""
         try:
             # Player changed alliances
+            current_alliance = get_alliance_tag_from_id(conn, player_data[2])
             old_alliance = get_alliance_tag_from_id(conn, player_data[3])
-            new_alliance = get_alliance_tag_from_id(conn, player_data[2])
 
-            alert_message = (
-                f"Player {player_data[1]} has changed alliances from "
-                f"**{old_alliance}** to **{new_alliance}**"
-            )
+            if current_alliance is None or current_alliance == "":
+                alert_message = f"Player {player_data[1]} left alliance {old_alliance}."
+            elif old_alliance is None or old_alliance == "":
+                alert_message = (
+                    f"Player {player_data[1]} joined alliance {current_alliance}."
+                )
+            else:
+                alert_message = (
+                    f"Player {player_data[1]} has changed alliances from "
+                    f"**{old_alliance}** to **{current_alliance}**"
+                )
 
             # Check recent message history
             if await self._message_exists(channel, alert_message):

--- a/bot/services/notification_service.py
+++ b/bot/services/notification_service.py
@@ -14,45 +14,59 @@ class NotificationService:
     def __init__(self):
         logger.info("Notification Service initialized")
 
+    def _is_data_too_old(self, timestamp_str: str) -> bool:
+        """Check if the data timestamp is more than 1 day old"""
+        timestamp = datetime.datetime.strptime(timestamp_str, "%Y-%m-%d")
+        return timestamp < datetime.datetime.utcnow() - datetime.timedelta(days=1)
+
+    def _format_channel_name(self, player_name: str) -> str:
+        """Format player name into valid Discord channel name"""
+        channel_name = player_name.replace(" ", "-").lower()
+        return channel_name.translate(str.maketrans("", "", string.punctuation))
+
+    def _find_player_channel(
+        self, guild: discord.Guild, player_name: str
+    ) -> discord.TextChannel:
+        """Find Discord channel matching player name"""
+        channel_name = self._format_channel_name(player_name)
+        logger.info(f"Checking for channel {channel_name}")
+
+        channel = discord.utils.get(guild.text_channels, name=channel_name)
+        if channel is not None:
+            logger.info(f"Found channel {channel}")
+        return channel
+
     async def send_alerts_for_guild(self, guild: discord.Guild) -> None:
         """Send alliance change alerts for a specific guild"""
         logger.info(f"Sending alerts for {str(guild.id)}")
 
         # Get game server config and connect to DB
         game_server = read_config_str(guild.id, ConfigKeys.GAME_SERVER, "")
-        conn = sqlite3.connect(get_connection_path(game_server))
 
-        await self._send_player_deleted_alert(conn, guild)
+        with sqlite3.connect(get_connection_path(game_server)) as conn:
+            await self._send_player_deleted_alert(conn, guild)
+            await self._send_alliance_change_alert(conn, guild)
 
+    async def _send_alliance_change_alert(
+        self, conn: sqlite3.Connection, guild: discord.Guild
+    ) -> None:
+        """Send an alert about player changes to the specified channel"""
         try:
             # Get all players that changed alliances
             query = "select * from v_player_change where alliance_changed=1 and current_population>0"
             rows = conn.execute(query)
 
             for row in rows:
-                # Check if data is too old
-                timestamp = datetime.datetime.strptime(row[11], "%Y-%m-%d")
-                if timestamp < datetime.datetime.utcnow() - datetime.timedelta(days=1):
+                if self._is_data_too_old(row[11]):
                     logger.info("Skipping all alerts because the data is too old.")
                     return
 
-                # Format channel name from player name
-                channel_name = row[1].replace(" ", "-").lower()
-                channel_name = channel_name.translate(
-                    str.maketrans("", "", string.punctuation)
-                )
-                logger.info(f"Checking for channel {channel_name}")
-
-                # Find matching channel
-                channel = discord.utils.get(guild.text_channels, name=channel_name)
+                channel = self._find_player_channel(guild, row[1])
                 if channel is not None:
-                    logger.info(f"Found channel {channel}")
                     await self._send_player_alert(conn, channel, row)
 
         except Exception as e:
             logger.error(f"Error sending alerts for guild {guild.id}: {e}")
-        finally:
-            conn.close()
 
     async def _send_player_alert(
         self, conn: sqlite3.Connection, channel: discord.TextChannel, player_data: tuple
@@ -80,23 +94,12 @@ class NotificationService:
             rows = conn.execute(query)
 
             for row in rows:
-                # Check if data is too old
-                timestamp = datetime.datetime.strptime(row[11], "%Y-%m-%d")
-                if timestamp < datetime.datetime.now() - datetime.timedelta(days=1):
+                if self._is_data_too_old(row[11]):
                     logger.info("Skipping all alerts because the data is too old.")
                     return
 
-                # Format channel name from player name
-                channel_name = row[1].replace(" ", "-").lower()
-                channel_name = channel_name.translate(
-                    str.maketrans("", "", string.punctuation)
-                )
-                logger.debug(f"Checking for channel {channel_name}")
-
-                # Find matching channel
-                channel = discord.utils.get(guild.text_channels, name=channel_name)
+                channel = self._find_player_channel(guild, row[1])
                 if channel is not None:
-                    logger.info(f"Found channel {channel}")
                     await channel.send(f"Player {row[1]} has deleted their account.")
 
         except Exception as e:

--- a/bot/test/test_boink_app.py
+++ b/bot/test/test_boink_app.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 from unittest.mock import patch
 from utils.constants import Colors, pytest_id
-from utils.config_manager import update_config
+from bot.services.config_service import update_config
 
 MOCK_GAME_SERVER = "https://ts2.x1.america.travian.com"
 

--- a/bot/test/test_boink_app.py
+++ b/bot/test/test_boink_app.py
@@ -1,8 +1,9 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from unittest.mock import patch
+from utils import logger
 from utils.constants import Colors, ConfigKeys, pytest_id
-from bot.services.config_service import update_config
+from services.config_service import dump_config, update_config
 
 MOCK_GAME_SERVER = "https://ts2.x1.america.travian.com"
 
@@ -71,6 +72,10 @@ class TestBoinkApp:
         update_config(
             str(mock_message.guild.id), ConfigKeys.GAME_SERVER, MOCK_GAME_SERVER
         )
+        logger.debug(
+            f"Guild ID: {mock_message.guild.id}, Mock Game Server: {MOCK_GAME_SERVER}"
+        )
+        logger.debug(f"Config Dump: {dump_config()}")
 
         # Mock database connection and cursor
         with patch("sqlite3.connect") as mock_connect:

--- a/bot/test/test_boink_app.py
+++ b/bot/test/test_boink_app.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from unittest.mock import patch
-from utils.logger import logger
 from utils.constants import Colors, ConfigKeys, pytest_id
 from services.config_service import dump_config, update_config
 
@@ -72,10 +71,6 @@ class TestBoinkApp:
         update_config(
             str(mock_message.guild.id), ConfigKeys.GAME_SERVER, MOCK_GAME_SERVER
         )
-        logger.debug(
-            f"Guild ID: {mock_message.guild.id}, Mock Game Server: {MOCK_GAME_SERVER}"
-        )
-        logger.debug(f"Config Dump: {dump_config()}")
 
         # Mock database connection and cursor
         with patch("sqlite3.connect") as mock_connect:

--- a/bot/test/test_boink_app.py
+++ b/bot/test/test_boink_app.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from unittest.mock import patch
-from utils import logger
+from utils.logger import logger
 from utils.constants import Colors, ConfigKeys, pytest_id
 from services.config_service import dump_config, update_config
 

--- a/bot/test/test_boink_app.py
+++ b/bot/test/test_boink_app.py
@@ -65,6 +65,7 @@ class TestBoinkApp:
         mock_message.content = "!boink search player_name"
         mock_message.channel.send = AsyncMock()
         mock_message.author.id = pytest_id
+        mock_message.guild.id = 1234
 
         # Add game_server to config to prevent that error
         update_config(

--- a/bot/test/test_boink_app.py
+++ b/bot/test/test_boink_app.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from unittest.mock import patch
-from utils.constants import Colors, pytest_id
+from utils.constants import Colors, ConfigKeys, pytest_id
 from bot.services.config_service import update_config
 
 MOCK_GAME_SERVER = "https://ts2.x1.america.travian.com"
@@ -67,7 +67,9 @@ class TestBoinkApp:
         mock_message.author.id = pytest_id
 
         # Add game_server to config to prevent that error
-        update_config(str(mock_message.guild.id), "game_server", MOCK_GAME_SERVER)
+        update_config(
+            str(mock_message.guild.id), ConfigKeys.GAME_SERVER, MOCK_GAME_SERVER
+        )
 
         # Mock database connection and cursor
         with patch("sqlite3.connect") as mock_connect:

--- a/bot/test/test_notification_service.py
+++ b/bot/test/test_notification_service.py
@@ -1,0 +1,139 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+import datetime
+import sqlite3
+import discord
+from bot.services.notification_service import NotificationService
+
+
+class TestNotificationService(unittest.TestCase):
+    def setUp(self):
+        self.service = NotificationService()
+
+        # Mock guild
+        self.guild = MagicMock(spec=discord.Guild)
+        self.guild.id = 123456
+
+        # Mock channel
+        self.channel = AsyncMock(spec=discord.TextChannel)
+        self.channel.name = "test-player"
+        self.channel.send = AsyncMock()
+
+        # Mock guild.text_channels for discord.utils.get
+        self.guild.text_channels = [self.channel]
+
+    @patch("bot.services.notification_service.read_config_str")
+    @patch("bot.services.notification_service.get_connection_path")
+    @patch("sqlite3.connect")
+    @patch("bot.services.notification_service.get_alliance_tag_from_id")
+    async def test_send_alerts_valid_data(
+        self, mock_get_alliance, mock_connect, mock_get_path, mock_config
+    ):
+        # Setup mocks
+        mock_config.return_value = "test_server"
+        mock_get_path.return_value = "test_path"
+
+        # Mock database connection and cursor
+        mock_conn = MagicMock(spec=sqlite3.Connection)
+        mock_connect.return_value = mock_conn
+
+        # Mock alliance tags
+        mock_get_alliance.side_effect = ["OLD", "NEW"]
+
+        # Create test data - valid timestamp (today)
+        today = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+        test_data = [
+            # player_id, name, current_alliance, prev_alliance, curr_villages, prev_villages,
+            # curr_pop, prev_pop, villages_changed, alliance_changed, pop_change, timestamp
+            (1, "Test Player", "NEW_ID", "OLD_ID", 2, 2, 100, 100, 0, 1, 0, today)
+        ]
+        mock_conn.execute.return_value = test_data
+
+        # Execute test
+        await self.service.send_alerts_for_guild(self.guild)
+
+        # Verify alerts were sent
+        self.channel.send.assert_called_once_with(
+            "Player Test Player has changed alliances from **OLD** to **NEW**"
+        )
+
+    @patch("bot.services.notification_service.read_config_str")
+    @patch("bot.services.notification_service.get_connection_path")
+    @patch("sqlite3.connect")
+    async def test_send_alerts_old_data(self, mock_connect, mock_get_path, mock_config):
+        # Setup mocks
+        mock_config.return_value = "test_server"
+        mock_get_path.return_value = "test_path"
+
+        # Mock database connection
+        mock_conn = MagicMock(spec=sqlite3.Connection)
+        mock_connect.return_value = mock_conn
+
+        # Create test data - old timestamp
+        old_date = (datetime.datetime.utcnow() - datetime.timedelta(days=2)).strftime(
+            "%Y-%m-%d"
+        )
+        test_data = [
+            (1, "Test Player", "NEW_ID", "OLD_ID", 2, 2, 100, 100, 0, 1, 0, old_date)
+        ]
+        mock_conn.execute.return_value = test_data
+
+        # Execute test
+        await self.service.send_alerts_for_guild(self.guild)
+
+        # Verify no alerts were sent
+        self.channel.send.assert_not_called()
+
+    @patch("bot.services.notification_service.read_config_str")
+    @patch("bot.services.notification_service.get_connection_path")
+    @patch("sqlite3.connect")
+    async def test_send_deleted_player_alert(
+        self, mock_connect, mock_get_path, mock_config
+    ):
+        # Setup mocks
+        mock_config.return_value = "test_server"
+        mock_get_path.return_value = "test_path"
+
+        # Mock database connection
+        mock_conn = MagicMock(spec=sqlite3.Connection)
+        mock_connect.return_value = mock_conn
+
+        # Create test data for deleted player (current_population = 0)
+        today = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+        test_data = [
+            (1, "Test Player", "ALLIANCE_ID", "OLD_ID", 0, 2, 0, 100, 1, 0, -100, today)
+        ]
+        mock_conn.execute.return_value = test_data
+
+        # Execute test
+        await self.service.send_alerts_for_guild(self.guild)
+
+        # Verify deletion alert was sent
+        self.channel.send.assert_called_once_with(
+            "Player Test Player has deleted their account."
+        )
+
+    @patch("bot.services.notification_service.read_config_str")
+    @patch("bot.services.notification_service.get_connection_path")
+    @patch("sqlite3.connect")
+    async def test_channel_not_found(self, mock_connect, mock_get_path, mock_config):
+        # Setup mocks
+        mock_config.return_value = "test_server"
+        mock_get_path.return_value = "test_path"
+
+        # Mock database connection
+        mock_conn = MagicMock(spec=sqlite3.Connection)
+        mock_connect.return_value = mock_conn
+
+        # Create test data
+        today = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+        test_data = [
+            (1, "Different Player", "NEW_ID", "OLD_ID", 2, 2, 100, 100, 0, 1, 0, today)
+        ]
+        mock_conn.execute.return_value = test_data
+
+        # Execute test
+        await self.service.send_alerts_for_guild(self.guild)
+
+        # Verify no alerts were sent (channel not found)
+        self.channel.send.assert_not_called()

--- a/bot/test/test_tracker_app.py
+++ b/bot/test/test_tracker_app.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from utils.constants import Colors, pytest_id
-from utils.config_manager import update_config
+from bot.services.config_service import update_config
 
 MOCK_GAME_SERVER = "https://ts2.x1.america.travian.com"
 MOCK_DB = "test_db.db"

--- a/databases/game_servers/views/v_player_change.sql
+++ b/databases/game_servers/views/v_player_change.sql
@@ -2,8 +2,8 @@ DROP VIEW IF EXISTS v_player_change;
 CREATE VIEW v_player_change AS
 WITH date_range AS (
     SELECT
-        MAX(date) AS current_date,
-        DATE(MAX(date), '-1 day') AS previous_date
+        MAX(date) AS today_timestamp,
+        DATE(MAX(date), '-1 day') AS yesterday_timestamp
     FROM v_map_history
 ),
 player_data AS (
@@ -13,10 +13,10 @@ player_data AS (
         m.alliance_id,
         m.village_id,
         m.population,
-        CASE WHEN m.date = d.current_date THEN 'current' ELSE 'previous' END AS data_type
+        CASE WHEN m.date = d.today_timestamp THEN 'current' ELSE 'previous' END AS data_type
     FROM v_map_history m
     CROSS JOIN date_range d
-    WHERE m.date IN (d.current_date, d.previous_date)
+    WHERE m.date IN (d.today_timestamp, d.yesterday_timestamp)
 ),
 aggregated_data AS (
     SELECT
@@ -43,6 +43,6 @@ SELECT
     (current_villages_count != previous_villages_count) AS villages_changed,
     (COALESCE(current_alliance_id, 'Unspecified') != COALESCE(previous_alliance_id, 'Unspecified')) AS alliance_changed,
     (current_population - previous_population) AS population_change,
-    (SELECT current_date FROM date_range) AS timestamp
+    (SELECT today_timestamp FROM date_range) AS created_at
 FROM aggregated_data;
 

--- a/databases/game_servers/views/v_player_change.sql
+++ b/databases/game_servers/views/v_player_change.sql
@@ -42,6 +42,7 @@ SELECT
     previous_population,
     (current_villages_count != previous_villages_count) AS villages_changed,
     (COALESCE(current_alliance_id, 'Unspecified') != COALESCE(previous_alliance_id, 'Unspecified')) AS alliance_changed,
-    (current_population - previous_population) AS population_change
+    (current_population - previous_population) AS population_change,
+    (SELECT current_date FROM date_range) AS timestamp
 FROM aggregated_data;
 


### PR DESCRIPTION
A solution for #32 and a refactor of the notification service to make it more extensible.

- [x] Creates a service directory refactoring core services out of utils
- [x] Creates a notification service that builds foundation of notification functionality for player DBs
- [x] Don't send outdated notifications 
- [x] Avoid duplicate posts on restart
- [x] Rewrite alliance change messaging to make it more clear what happened